### PR TITLE
Enforce line endings with .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*		text=auto
+run.ps1	text eol=crlf
+run.sh	text eol=lf


### PR DESCRIPTION
We run into the situation that based on the developers local git settings in some cases run.sh got CRLF ending instead of LF - and the execution of the command fails.
This change should ensure the correct line ending for linux and windows cases.